### PR TITLE
Added last_modified Caching

### DIFF
--- a/swiper/app/controllers/listings_controller.rb
+++ b/swiper/app/controllers/listings_controller.rb
@@ -98,6 +98,7 @@ class ListingsController < ApplicationController
             redirect_to sign_up_path, :flash => { :alert => "Please log in or sign up to reserve swipes!" }
         else
             @listing = Listing.find(params[:id])
+            fresh_when(etag: @listing, last_modified: @listing.updated_at, public: true)
         end
     end
 


### PR DESCRIPTION
This type of caching affects the loading of the listings page (we could
do the users page as well if we ever get that functionality. If we
reload the pages for listings multiple times, it will return a 304 Not
Modified if the listing hasn't been modified since the last access.